### PR TITLE
Add logout and signup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Assurez-vous de disposer d'une version récente de **Python** pour pouvoir lance
 3. Les tuiles disponibles s'affichent automatiquement à partir du fichier `apps.json`.
 
 Lors du premier lancement, un utilisateur **admin/admin** est créé automatiquement. Une petite fenêtre de connexion s'affiche : saisissez ces identifiants pour accéder à la plateforme.
+Il est désormais possible de créer d'autres comptes directement depuis l'écran de connexion grâce au bouton **"Créer un compte"**. Une fois connecté, un bouton **"Déconnexion"** apparaît en haut à droite pour revenir à l'écran de connexion.
 
 ## Fonctionnement
 
@@ -34,6 +35,7 @@ Lors du premier lancement, un utilisateur **admin/admin** est créé automatique
 - **Jeux** : la tuile "C02 Games" mène à un sous‑menu listé dans `games/games.json`. On y trouve actuellement un Pong fonctionnel et un futur Puissance 4.
 - **Discord** : la tuile "C02 Discord" ouvrira le lien vers le serveur (l'URL reste à renseigner).
 - **Gestion Users** : disponible uniquement pour les administrateurs, permet d'ajouter, modifier ou supprimer des comptes enregistrés dans `localStorage`.
+- **Déconnexion** : un bouton en haut à droite permet de quitter la session courante.
 
 Vérifiez la présence de Node si besoin pour d'autres outils :
 ```bash

--- a/css/styles.css
+++ b/css/styles.css
@@ -5,3 +5,5 @@ h1 { text-align:center; }
 .modal { position:fixed; top:50%; left:50%; transform:translate(-50%,-50%); background:#fff; padding:20px; border:1px solid #ccc; border-radius:8px; }
 .hidden { display:none; }
 #loginForm input { display:block; margin:5px 0; }
+#logoutBtn { position:absolute; top:10px; right:10px; }
+#signupForm input { display:block; margin:5px 0; }

--- a/index.html
+++ b/index.html
@@ -11,10 +11,20 @@
   <input id="loginUser" placeholder="Utilisateur">
   <input id="loginPass" type="password" placeholder="Mot de passe">
   <button id="loginBtn">Se connecter</button>
+  <button id="openSignup">Créer un compte</button>
+</div>
+
+<div id="signupForm" class="modal hidden">
+  <h2>Nouvel utilisateur</h2>
+  <input id="signupUser" placeholder="Utilisateur">
+  <input id="signupPass" type="password" placeholder="Mot de passe">
+  <button id="createUserBtn">Créer</button>
+  <button id="cancelSignup">Annuler</button>
 </div>
 
 <div id="app" class="hidden">
   <h1>C02 Group Apps</h1>
+  <button id="logoutBtn">Déconnexion</button>
   <div id="tiles" class="tile-container"></div>
   <div id="settings" class="modal hidden">
     <h2>Paramètres</h2>

--- a/js/app.js
+++ b/js/app.js
@@ -8,6 +8,13 @@ const loginBtn = document.getElementById('loginBtn');
 const loginUser = document.getElementById('loginUser');
 const loginPass = document.getElementById('loginPass');
 const appContainer = document.getElementById('app');
+const openSignup = document.getElementById('openSignup');
+const signupForm = document.getElementById('signupForm');
+const signupUser = document.getElementById('signupUser');
+const signupPass = document.getElementById('signupPass');
+const createUserBtn = document.getElementById('createUserBtn');
+const cancelSignup = document.getElementById('cancelSignup');
+const logoutBtn = document.getElementById('logoutBtn');
 
 function initUsers() {
   if (!localStorage.getItem('users')) {
@@ -58,6 +65,29 @@ function showLogin(){
   loginForm.classList.remove('hidden');
 }
 
+function logout(){
+  sessionStorage.removeItem('currentUser');
+  showLogin();
+}
+
+function createUser(){
+  const users = getUsers();
+  if(!signupUser.value || !signupPass.value){
+    alert('Champs manquants');
+    return;
+  }
+  if(users.some(u=>u.username===signupUser.value)){
+    alert('Utilisateur existant');
+    return;
+  }
+  users.push({username:signupUser.value, password:signupPass.value, role:'user'});
+  localStorage.setItem('users', JSON.stringify(users));
+  signupUser.value='';
+  signupPass.value='';
+  signupForm.classList.add('hidden');
+  alert('Utilisateur créé');
+}
+
 function fetchApps() {
   return fetch('apps.json').then(r => r.json());
 }
@@ -90,6 +120,10 @@ autoUpdateCheckbox.addEventListener('change', e => {
 closeSettingsButton.addEventListener('click', () => settingsModal.classList.add('hidden'));
 
 loginBtn.addEventListener('click', doLogin);
+openSignup.addEventListener('click', () => signupForm.classList.remove('hidden'));
+cancelSignup.addEventListener('click', () => signupForm.classList.add('hidden'));
+createUserBtn.addEventListener('click', createUser);
+logoutBtn.addEventListener('click', logout);
 
 initUsers();
 if (currentUser()) {


### PR DESCRIPTION
## Summary
- allow creating new users from the login form
- add logout button
- document new signup/logout features

## Testing
- `node -v`
- `python3 --version`
- `python3 -m http.server 8000` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6841c34eaadc832d80c92e39493e8b05