### PR TITLE
Enable Pong 2‑player mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Il est désormais possible de créer d'autres comptes directement depuis l'écra
 ## Fonctionnement
 
 - **Mise à jour** : la page lit le fichier `apps.json` pour afficher les applications. Le bouton "Paramètres" permet d'activer la mise à jour automatique ou d'exécuter une mise à jour manuelle.
-- **Jeux** : la tuile "C02 Games" mène à un sous‑menu listé dans `games/games.json`. On y trouve un Pong fonctionnel ainsi qu'un Puissance 4 jouable en 1v1 ou contre l'ordinateur.
+- **Jeux** : la tuile "C02 Games" mène à un sous‑menu listé dans `games/games.json`. On y trouve un Pong jouable en solo ou à deux sur le même clavier, ainsi qu'un Puissance 4 jouable en 1v1 ou contre l'ordinateur.
 - **Discord** : la tuile "C02 Discord" ouvrira le lien vers le serveur (l'URL reste à renseigner).
 - **Gestion Users** : disponible uniquement pour les administrateurs, permet d'ajouter, modifier ou supprimer les comptes enregistrés côté serveur.
 - **Déconnexion** : un bouton en haut à droite permet de quitter la session courante.

--- a/games/pong.html
+++ b/games/pong.html
@@ -9,6 +9,7 @@ canvas { background:#000; display:block; margin:0 auto; }
 </head>
 <body>
 <canvas id="pong" width="600" height="400"></canvas>
+<button id="modeBtn">Mode 2 joueurs</button>
 <button onclick="window.location.href='index.html'">Retour</button>
 <script src="pong.js"></script>
 </body>

--- a/games/pong.js
+++ b/games/pong.js
@@ -6,13 +6,19 @@ let playerY = canvas.height/2 - paddleHeight/2;
 let aiY = playerY;
 let ballX = canvas.width/2, ballY = canvas.height/2;
 let ballVX = 4, ballVY = 4;
+let twoPlayers = false;
+const keys = {};
+const modeBtn = document.getElementById('modeBtn');
+
+document.addEventListener('keydown', e => keys[e.key] = true);
+document.addEventListener('keyup', e => keys[e.key] = false);
 
 function draw() {
   ctx.clearRect(0,0,canvas.width,canvas.height);
   ctx.fillStyle = '#fff';
   // player paddle
   ctx.fillRect(10, playerY, paddleWidth, paddleHeight);
-  // ai paddle
+  // ai or second player paddle
   ctx.fillRect(canvas.width-20, aiY, paddleWidth, paddleHeight);
   // ball
   ctx.beginPath();
@@ -21,19 +27,29 @@ function draw() {
 }
 
 function update() {
+  if (keys['z'] || keys['Z']) playerY -= 6;
+  if (keys['s'] || keys['S']) playerY += 6;
+  playerY = Math.max(0, Math.min(canvas.height - paddleHeight, playerY));
+
+  if (twoPlayers) {
+    if (keys['ArrowUp']) aiY -= 6;
+    if (keys['ArrowDown']) aiY += 6;
+  } else {
+    aiY += (ballY - aiY - paddleHeight/2) * 0.05;
+  }
+  aiY = Math.max(0, Math.min(canvas.height - paddleHeight, aiY));
+
   ballX += ballVX;
   ballY += ballVY;
   if (ballY <=0 || ballY >= canvas.height) ballVY *= -1;
   if (ballX <=20 && ballY>playerY && ballY<playerY+paddleHeight) ballVX *= -1;
   if (ballX >=canvas.width-20 && ballY>aiY && ballY<aiY+paddleHeight) ballVX *= -1;
   if (ballX<0 || ballX>canvas.width){ ballX=canvas.width/2; ballY=canvas.height/2; }
-  aiY += (ballY - aiY - paddleHeight/2)*0.05;
 }
 
 function loop(){ update(); draw(); requestAnimationFrame(loop); }
 loop();
-
-canvas.addEventListener('mousemove', e => {
-  const rect = canvas.getBoundingClientRect();
-  playerY = e.clientY - rect.top - paddleHeight/2;
+modeBtn.addEventListener('click', () => {
+  twoPlayers = !twoPlayers;
+  modeBtn.textContent = twoPlayers ? 'Mode Solo' : 'Mode 2 joueurs';
 });


### PR DESCRIPTION
## Summary
- add two-player toggle button in `pong.html`
- let the left paddle move with **Z/S** and right paddle with arrow keys
- AI moves only in solo mode
- mention two-player Pong in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841d023073c832d88c7eb27446b14cb