### PR TITLE
Mise à jour tuiles et préférences serveur

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1,8 +1,6 @@
 {
   "apps": [
     { "id": "games", "name": "C02 Games", "link": "games/index.html" },
-    { "id": "discord", "name": "C02 Discord", "link": "https://discord.com/invite/" },
-    { "id": "settings", "name": "Paramètres", "settings": true },
-    { "id": "users", "name": "Gestion Users", "link": "users.html", "admin": true }
+    { "id": "discord", "name": "C02 Discord", "link": "https://discord.com/invite/" }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -25,7 +25,11 @@
 <div id="app" class="hidden">
   <h1>C02 Group Apps</h1>
   <button id="logoutBtn">Déconnexion</button>
-  <div id="tiles" class="tile-container"></div>
+  <div id="tiles" class="tile-container">
+    <div id="settingsTile" class="tile">Paramètres</div>
+    <div id="usersTile" class="tile hidden">Gestion Users</div>
+    <div id="appTiles" class="tile-container"></div>
+  </div>
   <div id="settings" class="modal hidden">
     <h2>Paramètres</h2>
     <label><input type="checkbox" id="autoUpdate"> Mise à jour automatique</label>

--- a/server.js
+++ b/server.js
@@ -53,6 +53,15 @@ app.get('/api/current', (req, res) => {
   res.json({ user: req.session.user || null });
 });
 
+app.get('/api/preferences', (req, res) => {
+  res.json({ autoUpdate: req.session.autoUpdate !== false });
+});
+
+app.post('/api/preferences', (req, res) => {
+  req.session.autoUpdate = !!req.body.autoUpdate;
+  res.json({ ok: true });
+});
+
 app.get('/api/users', (req, res) => {
   if (!req.session.user || req.session.user.role !== 'admin') {
     return res.status(403).json({ error: 'forbidden' });


### PR DESCRIPTION
## Summary
- render settings and admin user tiles directly in the page
- store `autoUpdate` in the session with new `/api/preferences` routes
- fetch preference on login and schedule auto refresh

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841cf6d0670832d9f5982af0a369690