### PR TITLE
Fix enter key login

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -163,6 +163,8 @@ usersTile.addEventListener('click', () => window.location.href = 'users.html');
 closeSettingsButton.addEventListener('click', () => settingsModal.classList.add('hidden'));
 
 loginBtn.addEventListener('click', doLogin);
+loginUser.addEventListener('keydown', e => { if(e.key === 'Enter') doLogin(); });
+loginPass.addEventListener('keydown', e => { if(e.key === 'Enter') doLogin(); });
 openSignup.addEventListener('click', () => signupForm.classList.remove('hidden'));
 cancelSignup.addEventListener('click', () => signupForm.classList.add('hidden'));
 createUserBtn.addEventListener('click', createUser);


### PR DESCRIPTION
## Summary
- allow Enter key to submit the login form

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684202fe7fb8832d88fd6375b935e0a4