### PR TITLE
Add animated multi-step menu for Pong

### DIFF
--- a/games/pong.css
+++ b/games/pong.css
@@ -1,7 +1,9 @@
 body{margin:0;background:#000;color:#fff;font-family:Arial,sans-serif;overflow:hidden}
 canvas{background:#000;display:block;margin:0 auto}
-.overlay{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(0,0,0,0.8);padding:20px;border-radius:8px;text-align:center;color:#fff}
+.overlay{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(0,0,0,0.8);padding:20px;border-radius:8px;text-align:center;color:#fff;overflow:hidden}
 .hidden{display:none}
-.buttons button, #pauseBtn{margin:5px;padding:10px 20px;background:#0055a4;border:none;border-radius:5px;color:#fff;cursor:pointer}
-.buttons button:hover,#pauseBtn:hover{background:#004080}
+.buttons button, #pauseBtn,.nav button{margin:5px;padding:10px 20px;background:#0055a4;border:none;border-radius:5px;color:#fff;cursor:pointer}
+.buttons button:hover,#pauseBtn:hover,.nav button:hover{background:#004080}
+.pages{display:flex;width:400%;transition:transform .5s}
+.page{width:100%;flex-shrink:0;box-sizing:border-box}
 .history{margin-bottom:10px;font-size:14px}

--- a/games/pong.html
+++ b/games/pong.html
@@ -7,22 +7,46 @@
 </head>
 <body>
 <div id="menu" class="overlay">
-  <h1>Pong</h1>
-  <div id="history" class="history"></div>
-  <label>Joueur 1: <input id="p1Name" value="Joueur 1"></label>
-  <label>Joueur 2: <input id="p2Name" value="Joueur 2"></label>
-  <label>Mode:
-    <select id="mode">
-      <option value="pvp">1 vs 1</option>
-      <option value="ai">1 vs Ordinateur</option>
-    </select>
-  </label>
-  <label>Points pour gagner: <input id="maxScore" type="number" min="1" value="5"></label>
-  <label><input type="checkbox" id="infinite"> Infini</label>
-  <div class="buttons">
-    <button id="startBtn">Commencer</button>
-    <button id="openSettings">Paramètres</button>
-    <button class="back-button" onclick="window.location.href='index.html'">Menu principal</button>
+  <div id="pages" class="pages">
+    <div class="page" id="page0">
+      <h1>Pong</h1>
+      <div id="history" class="history"></div>
+      <div class="buttons">
+        <button id="startBtn">Commencer</button>
+        <button id="openSettings">Paramètres</button>
+        <button class="back-button" onclick="window.location.href='index.html'">Menu principal</button>
+      </div>
+    </div>
+    <div class="page" id="page1">
+      <h2>Mode de jeu</h2>
+      <label>
+        <select id="mode">
+          <option value="pvp">1 vs 1</option>
+          <option value="ai">1 vs Ordinateur</option>
+        </select>
+      </label>
+      <div class="nav">
+        <button class="prev">Retour</button>
+        <button class="next">Suivant</button>
+      </div>
+    </div>
+    <div class="page" id="page2">
+      <label>Points pour gagner: <input id="maxScore" type="number" min="1" value="5"></label>
+      <label><input type="checkbox" id="infinite"> Infini</label>
+      <label>Accélération toutes les <input id="accel" type="number" min="0" value="0"> frappes</label>
+      <div class="nav">
+        <button class="prev">Retour</button>
+        <button class="next">Suivant</button>
+      </div>
+    </div>
+    <div class="page" id="page3">
+      <label>Joueur 1: <input id="p1Name" value="Joueur 1"></label>
+      <label>Joueur 2: <input id="p2Name" value="Joueur 2"></label>
+      <div class="nav">
+        <button class="prev">Retour</button>
+        <button id="launch">Jouer</button>
+      </div>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- refactor Pong main menu with sliding pages
- add inputs for acceleration and score options
- disable score field when infinite mode is active
- reset menu after leaving a game
- support AI vs AI demo while menu is displayed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684203d1c494832d8c3f117be600d239