### PR TITLE
Add Emoji Catcher game

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Il est désormais possible de créer d'autres comptes directement depuis l'écra
 ## Fonctionnement
 
 - **Mise à jour** : la page lit le fichier `apps.json` pour afficher les applications. Le bouton "Paramètres" permet d'activer la mise à jour automatique ou d'exécuter une mise à jour manuelle.
-- **Jeux** : la tuile "C02 Games" mène à un sous‑menu listé dans `games/games.json`. On y trouve un Pong jouable en solo ou à deux sur le même clavier, ainsi qu'un Puissance 4 jouable en 1v1 ou contre l'ordinateur.
+- **Jeux** : la tuile "C02 Games" mène à un sous‑menu mis à jour automatiquement à chaque chargement. La liste est construite en scannant les fichiers HTML du dossier `games`. On y trouve un Pong jouable en solo ou à deux sur le même clavier, un Puissance 4 jouable en 1v1 ou contre l'ordinateur, ainsi que le jeu "Emoji Catcher".
 - **Discord** : la tuile "C02 Discord" ouvrira le lien vers le serveur (l'URL reste à renseigner).
 - **Gestion Users** : disponible uniquement pour les administrateurs, permet d'ajouter, modifier ou supprimer les comptes enregistrés côté serveur.
 - **Déconnexion** : un bouton en haut à droite permet de quitter la session courante.

--- a/games/emoji-texts.json
+++ b/games/emoji-texts.json
@@ -1,0 +1,18 @@
+{
+  "fr": {
+    "title": "Emoji Catcher",
+    "start": "Démarrer",
+    "restart": "Recommencer",
+    "score": "Score",
+    "lives": "Vies",
+    "gameOver": "Partie terminée"
+  },
+  "en": {
+    "title": "Emoji Catcher",
+    "start": "Start",
+    "restart": "Restart",
+    "score": "Score",
+    "lives": "Lives",
+    "gameOver": "Game Over"
+  }
+}

--- a/games/emoji.html
+++ b/games/emoji.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>Emoji Catcher</title>
+<style>
+body{margin:0;background:#222;color:#fff;font-family:Arial,sans-serif;text-align:center}
+canvas{background:#000;border:2px solid #fff;display:block;margin:20px auto}
+#hud{display:flex;justify-content:center;gap:20px;margin-top:10px}
+button{margin:5px;padding:10px 20px;background:#0055a4;border:none;border-radius:5px;color:#fff;cursor:pointer}
+button:hover{background:#004080}
+</style>
+</head>
+<body>
+<h1 id="title">Emoji Catcher</h1>
+<div id="hud" role="status" aria-live="polite">
+  <span id="scoreLabel">Score: <span id="score">0</span></span>
+  <span id="livesLabel">Vies: <span id="lives">3</span></span>
+  <span id="bestLabel">Best: <span id="best">0</span></span>
+</div>
+<canvas id="gameCanvas" width="480" height="600" aria-label="Emoji Catcher"></canvas>
+<div>
+  <button id="startBtn">Démarrer</button>
+  <button class="back-button" onclick="window.location.href='index.html'">Retour</button>
+</div>
+<script src="emoji.js"></script>
+</body>
+</html>

--- a/games/emoji.js
+++ b/games/emoji.js
@@ -1,0 +1,49 @@
+let texts={};
+fetch('emoji-texts.json').then(r=>r.json()).then(data=>{
+  const lang=navigator.language.startsWith('fr')?'fr':'en';
+  texts=data[lang];
+  document.title=texts.title;
+  document.getElementById('title').textContent=texts.title;
+  document.getElementById('startBtn').textContent=texts.start;
+  updateHUD();
+});
+
+const canvas=document.getElementById('gameCanvas');
+const ctx=canvas.getContext('2d');
+let width=canvas.width, height=canvas.height;
+let basket={x:width/2-40,y:height-30,width:80,height:20};
+let items=[];
+let score=0,lives=3,high=Number(localStorage.getItem('emojiHigh')||0);
+let running=false,last=0,spawn=0;
+const interval=700;
+const emojis=['\u{1F34E}','\u{1F34C}','\u{1F347}','\u{1F349}','\u{1F353}','\u{1F34D}','\u{1F34B}','\u{1F351}','\u{1F352}'];
+
+function resize(){
+  width=Math.min(window.innerWidth-40,480);
+  height=Math.min(window.innerHeight-200,600);
+  canvas.width=width;canvas.height=height;
+  basket.y=height-30;
+}
+window.addEventListener('resize',resize);
+resize();
+
+function move(x){basket.x=Math.max(0,Math.min(width-basket.width,x));}
+canvas.addEventListener('mousemove',e=>running&&move(e.offsetX-basket.width/2));
+canvas.addEventListener('touchmove',e=>{if(!running)return;e.preventDefault();const rect=canvas.getBoundingClientRect();move(e.touches[0].clientX-rect.left-basket.width/2);},{passive:false});
+document.addEventListener('keydown',e=>{if(!running)return;if(e.key==='ArrowLeft')move(basket.x-20);if(e.key==='ArrowRight')move(basket.x+20);});
+
+function spawnItem(){const emoji=emojis[Math.floor(Math.random()*emojis.length)];items.push({emoji,x:Math.random()*(width-32)+16,y:-30,size:30,speed:2+Math.random()*2});}
+
+function update(dt){spawn+=dt;if(spawn>interval){spawnItem();spawn=0;}items.forEach(it=>{it.y+=it.speed;});items=items.filter(it=>{if(it.y>height) return false;if(it.y>basket.y-it.size && it.x>basket.x && it.x<basket.x+basket.width){if(it.emoji==='\u{1F34E}')score++;else{lives--;if(lives<=0){gameOver();}}return false;}return true;});}
+
+function draw(){ctx.clearRect(0,0,width,height);ctx.fillStyle='#fff';ctx.fillRect(basket.x,basket.y,basket.width,basket.height);ctx.font='28px serif';items.forEach(it=>ctx.fillText(it.emoji,it.x-15,it.y));}
+
+function loop(t){if(!running)return;requestAnimationFrame(loop);const dt=t-(last||t);last=t;update(dt);draw();updateHUD();}
+
+function updateHUD(){document.getElementById('score').textContent=score;document.getElementById('lives').textContent=lives;document.getElementById('best').textContent=high;document.getElementById('scoreLabel').firstChild.textContent=texts.score+': ';document.getElementById('livesLabel').firstChild.textContent=texts.lives+': ';}
+
+function start(){score=0;lives=3;items=[];running=true;last=0;spawn=interval;document.getElementById('startBtn').textContent=texts.restart;loop();}
+
+function gameOver(){running=false;ctx.fillStyle='rgba(0,0,0,0.5)';ctx.fillRect(0,0,width,height);ctx.fillStyle='#fff';ctx.font='30px Arial';ctx.fillText(texts.gameOver,width/2-ctx.measureText(texts.gameOver).width/2,height/2);high=Math.max(high,score);localStorage.setItem('emojiHigh',high);}
+
+document.getElementById('startBtn').addEventListener('click',start);

--- a/games/games.js
+++ b/games/games.js
@@ -1,7 +1,7 @@
 const gameTiles = document.getElementById('gameTiles');
 
 function fetchGames() {
-  return fetch('games.json').then(r => r.json());
+  return fetch('/api/games').then(r => r.json());
 }
 
 function renderGames(list) {

--- a/games/games.json
+++ b/games/games.json
@@ -1,6 +1,7 @@
 {
   "games": [
     { "id": "pong", "name": "Pong", "link": "pong.html" },
-    { "id": "connect4", "name": "Puissance 4", "link": "connect4.html" }
+    { "id": "connect4", "name": "Puissance 4", "link": "connect4.html" },
+    { "id": "emoji", "name": "Emoji Catcher", "link": "emoji.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- create new game Emoji Catcher with responsive canvas and keyboard/mouse/touch controls
- store UI texts in a JSON file for i18n
- list Emoji Catcher in the games menu
- dynamically scan the games folder through /api/games on each load

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684207ba7794832d9cc821e74c383aa4