### PR TITLE
Adjust menu button layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5,7 +5,13 @@ h1 { text-align:center; }
 .modal { position:fixed; top:50%; left:50%; transform:translate(-50%,-50%); background:#fff; padding:20px; border:1px solid #ccc; border-radius:8px; }
 .hidden { display:none; }
 #loginForm input { display:block; margin:5px 0; }
-#logoutBtn { position:absolute; top:10px; right:10px; }
+#topButtons {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  gap: 10px;
+}
 #signupForm input { display:block; margin:5px 0; }
 
 /* Style pour les boutons de retour */

--- a/index.html
+++ b/index.html
@@ -24,10 +24,12 @@
 
 <div id="app" class="hidden">
   <h1>C02 Group Apps</h1>
-  <button id="logoutBtn">Déconnexion</button>
+  <div id="topButtons">
+    <button id="logoutBtn">Déconnexion</button>
+    <button id="settingsBtn">Paramètres</button>
+    <button id="usersBtn" class="hidden">Gestion Users</button>
+  </div>
   <div id="tiles" class="tile-container">
-    <div id="settingsTile" class="tile">Paramètres</div>
-    <div id="usersTile" class="tile hidden">Gestion Users</div>
     <div id="appTiles" class="tile-container"></div>
   </div>
   <div id="settings" class="modal hidden">

--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,6 @@
 const dynamicTiles = document.getElementById('appTiles');
-const settingsTile = document.getElementById('settingsTile');
-const usersTile = document.getElementById('usersTile');
+const settingsBtn = document.getElementById('settingsBtn');
+const usersBtn = document.getElementById('usersBtn');
 const tilesContainer = dynamicTiles;
 const settingsModal = document.getElementById('settings');
 const autoUpdateCheckbox = document.getElementById('autoUpdate');
@@ -147,9 +147,9 @@ function setupAutoUpdate(enabled){
 
 function updateAdminTile(){
   if(isAdmin()){
-    usersTile.classList.remove('hidden');
+    usersBtn.classList.remove('hidden');
   } else {
-    usersTile.classList.add('hidden');
+    usersBtn.classList.add('hidden');
   }
 }
 
@@ -158,8 +158,8 @@ autoUpdateCheckbox.addEventListener('change', e => {
   savePreferences(e.target.checked);
   setupAutoUpdate(e.target.checked);
 });
-settingsTile.addEventListener('click', () => settingsModal.classList.remove('hidden'));
-usersTile.addEventListener('click', () => window.location.href = 'users.html');
+settingsBtn.addEventListener('click', () => settingsModal.classList.remove('hidden'));
+usersBtn.addEventListener('click', () => window.location.href = 'users.html');
 closeSettingsButton.addEventListener('click', () => settingsModal.classList.add('hidden'));
 
 loginBtn.addEventListener('click', doLogin);


### PR DESCRIPTION
## Summary
- remove Paramètres and Gestion Users tiles from the tile grid
- add Paramètres and Gestion Users buttons next to Déconnexion
- style the new button container
- update JavaScript to handle new buttons

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684209725c24832db0973ece5325f8e6