### PR TITLE
Add cross-page fade animation

### DIFF
--- a/css/transitions.css
+++ b/css/transitions.css
@@ -1,0 +1,2 @@
+.fade { opacity: 0; transition: opacity 0.3s ease; }
+.fade.visible { opacity: 1; }

--- a/games/connect4.html
+++ b/games/connect4.html
@@ -31,8 +31,9 @@ td:hover { background: #ddd; }
 #restart:hover { background:#004080; }
 #status { font-weight: bold; margin-top:10px; }
 </style>
+<link rel="stylesheet" href="../css/transitions.css">
 </head>
-<body>
+<body class="fade">
 <h1>Puissance 4</h1>
 <div id="menu">
   <button id="pvp">1 vs 1</button>
@@ -41,7 +42,8 @@ td:hover { background: #ddd; }
 <div id="boardContainer" class="hidden"></div>
 <p id="status"></p>
 <button id="restart" class="hidden">Recommencer</button>
-<button class="back-button" onclick="window.location.href='index.html'">Retour</button>
+<button class="back-button" onclick="navigate('index.html')">Retour</button>
 <script src="connect4.js"></script>
+<script src="../js/nav.js"></script>
 </body>
 </html>

--- a/games/games.js
+++ b/games/games.js
@@ -9,7 +9,7 @@ function renderGames(list) {
     const div = document.createElement('div');
     div.className = 'tile';
     div.textContent = game.name;
-    div.addEventListener('click', () => window.location.href = game.link);
+    div.addEventListener('click', () => navigate(game.link));
     gameTiles.appendChild(div);
   });
 }

--- a/games/index.html
+++ b/games/index.html
@@ -4,11 +4,13 @@
 <meta charset="UTF-8">
 <title>C02 Games</title>
 <link rel="stylesheet" href="../css/styles.css">
+<link rel="stylesheet" href="../css/transitions.css">
 </head>
-<body>
+<body class="fade">
 <h1>C02 Games</h1>
-<button class="back-button" onclick="window.location.href='../index.html'">Retour</button>
+<button class="back-button" onclick="navigate('../index.html')">Retour</button>
 <div id="gameTiles" class="tile-container"></div>
 <script src="games.js"></script>
+<script src="../js/nav.js"></script>
 </body>
 </html>

--- a/games/pong.html
+++ b/games/pong.html
@@ -4,8 +4,9 @@
 <meta charset="UTF-8">
 <title>Pong</title>
 <link rel="stylesheet" href="pong.css">
+<link rel="stylesheet" href="../css/transitions.css">
 </head>
-<body>
+<body class="fade">
 <div id="menu" class="overlay">
   <div id="pages" class="pages">
     <div class="page" id="page0">
@@ -14,7 +15,7 @@
       <div class="buttons">
         <button id="startBtn">Commencer</button>
         <button id="openSettings">Paramètres</button>
-        <button class="back-button" onclick="window.location.href='index.html'">Menu principal</button>
+        <button class="back-button" onclick="navigate('index.html')">Menu principal</button>
       </div>
     </div>
     <div class="page" id="page1">
@@ -62,16 +63,17 @@
   <button id="resumeBtn">Reprendre</button>
   <button id="pauseMenuBtn">Menu du jeu</button>
   <button id="quitBtn">Quitter la partie</button>
-  <button id="menuBtn" onclick="window.location.href='index.html'">Menu principal</button>
+  <button id="menuBtn" onclick="navigate('index.html')">Menu principal</button>
 </div>
 
 <div id="end" class="overlay hidden">
   <h2 id="endMsg"></h2>
-  <button id="endMenuBtn" onclick="window.location.href='index.html'">Menu principal</button>
+  <button id="endMenuBtn" onclick="navigate('index.html')">Menu principal</button>
 </div>
 
 <canvas id="pong"></canvas>
 <button id="pauseBtn" class="hidden">Pause</button>
 <script src="pong.js"></script>
+<script src="../js/nav.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
 <meta charset="UTF-8">
 <title>C02 Group Apps</title>
 <link rel="stylesheet" href="css/styles.css">
+<link rel="stylesheet" href="css/transitions.css">
 </head>
-<body>
+<body class="fade">
 <div id="loginForm" class="modal hidden">
   <h2>Connexion</h2>
   <input id="loginUser" placeholder="Utilisateur">
@@ -38,5 +39,6 @@
   </div>
 </div>
 <script src="js/app.js"></script>
+<script src="js/nav.js"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -126,7 +126,7 @@ function renderTiles(apps) {
     const div = document.createElement('div');
     div.className = 'tile';
     div.textContent = app.name;
-    div.addEventListener('click', () => window.location.href = app.link);
+    div.addEventListener('click', () => navigate(app.link));
     tilesContainer.appendChild(div);
   });
 }
@@ -159,7 +159,7 @@ autoUpdateCheckbox.addEventListener('change', e => {
   setupAutoUpdate(e.target.checked);
 });
 settingsTile.addEventListener('click', () => settingsModal.classList.remove('hidden'));
-usersTile.addEventListener('click', () => window.location.href = 'users.html');
+usersTile.addEventListener('click', () => navigate('users.html'));
 closeSettingsButton.addEventListener('click', () => settingsModal.classList.add('hidden'));
 
 loginBtn.addEventListener('click', doLogin);

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.body.classList.add('visible');
+});
+
+window.navigate = function(url) {
+  document.body.classList.remove('visible');
+  setTimeout(() => {
+    window.location.href = url;
+  }, 300);
+};

--- a/js/users.js
+++ b/js/users.js
@@ -2,7 +2,7 @@ async function checkAdmin() {
   const r = await fetch('/api/current');
   const data = await r.json();
   if (!data.user || data.user.role !== 'admin') {
-    window.location.href = 'index.html';
+    navigate('index.html');
   }
 }
 
@@ -30,7 +30,7 @@ async function loadUsers() {
     users = data.users;
     render();
   } else {
-    window.location.href = 'index.html';
+    navigate('index.html');
   }
 }
 

--- a/users.html
+++ b/users.html
@@ -4,10 +4,11 @@
 <meta charset="UTF-8">
 <title>Gestion utilisateurs</title>
 <link rel="stylesheet" href="css/styles.css">
+<link rel="stylesheet" href="css/transitions.css">
 </head>
-<body>
+<body class="fade">
 <h1>Gestion des utilisateurs</h1>
-<button class="back-button" onclick="window.location.href='index.html'">Retour</button>
+<button class="back-button" onclick="navigate('index.html')">Retour</button>
 <table id="userTable"></table>
 <h2>Ajouter / Modifier</h2>
 <input id="userName" placeholder="Nom">
@@ -17,6 +18,7 @@
   <option value="admin">admin</option>
 </select>
 <button id="saveUser">Enregistrer</button>
+<script src="js/nav.js"></script>
 <script src="js/users.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add generic page fade CSS rules
- implement navigation helper for fading between pages
- use new transition on app tiles and user management
- include CSS and script across app pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842098de7d4832db343db02ea576cf4