### PR TITLE
Fix emoji game start button

### DIFF
--- a/public/games/emoji/emoji.js
+++ b/public/games/emoji/emoji.js
@@ -42,8 +42,19 @@ function loop(t){if(!running)return;requestAnimationFrame(loop);const dt=t-(last
 
 function updateHUD(){document.getElementById('score').textContent=score;document.getElementById('lives').textContent=lives;document.getElementById('best').textContent=high;document.getElementById('scoreLabel').firstChild.textContent=texts.score+': ';document.getElementById('livesLabel').firstChild.textContent=texts.lives+': ';}
 
-function start(){score=0;lives=3;items=[];running=true;last=0;spawn=interval;document.getElementById('startBtn').textContent=texts.restart;loop();}
+function start(){
+  if(running)return; // avoid extra loops
+  score=0;lives=3;items=[];running=true;last=0;spawn=interval;
+  const btn=document.getElementById('startBtn');
+  btn.textContent=texts.restart;
+  btn.disabled=true; // disable while game active
+  loop();
+}
 
-function gameOver(){running=false;ctx.fillStyle='rgba(0,0,0,0.5)';ctx.fillRect(0,0,width,height);ctx.fillStyle='#fff';ctx.font='30px Arial';ctx.fillText(texts.gameOver,width/2-ctx.measureText(texts.gameOver).width/2,height/2);high=Math.max(high,score);localStorage.setItem('emojiHigh',high);updateHUD();}
+function gameOver(){
+  running=false;ctx.fillStyle='rgba(0,0,0,0.5)';ctx.fillRect(0,0,width,height);ctx.fillStyle='#fff';ctx.font='30px Arial';ctx.fillText(texts.gameOver,width/2-ctx.measureText(texts.gameOver).width/2,height/2);
+  high=Math.max(high,score);localStorage.setItem('emojiHigh',high);updateHUD();
+  document.getElementById('startBtn').disabled=false;
+}
 
 document.getElementById('startBtn').addEventListener('click',start);


### PR DESCRIPTION
## Summary
- ignore clicks on `Start` when the game is running
- disable the start button while playing and enable it after game over

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684217bd9110832d8f3d416aecdb3e66