### PR TITLE
Add pause toggle to Emoji game

### DIFF
--- a/public/games/emoji/emoji.js
+++ b/public/games/emoji/emoji.js
@@ -19,7 +19,7 @@ let width=canvas.width, height=canvas.height;
 let basket={x:width/2-40,y:height-30,width:80,height:20};
 let items=[];
 let score=0,lives=3,high=Number(localStorage.getItem('emojiHigh')||0);
-let running=false,last=0,spawn=0;
+let running=false,last=0,spawn=0,paused=false;
 let interval=700;
 let speedMult=1;
 const emojis=['\u{1F34E}','\u{1F34C}','\u{1F347}','\u{1F349}','\u{1F353}','\u{1F34D}','\u{1F34B}','\u{1F351}','\u{1F352}'];
@@ -36,7 +36,15 @@ resize();
 function move(x){basket.x=Math.max(0,Math.min(width-basket.width,x));}
 canvas.addEventListener('mousemove',e=>running&&move(e.offsetX-basket.width/2));
 canvas.addEventListener('touchmove',e=>{if(!running)return;e.preventDefault();const rect=canvas.getBoundingClientRect();move(e.touches[0].clientX-rect.left-basket.width/2);},{passive:false});
-document.addEventListener('keydown',e=>{if(!running)return;if(e.key==='ArrowLeft')move(basket.x-20);if(e.key==='ArrowRight')move(basket.x+20);});
+document.addEventListener('keydown',e=>{
+  if(e.key==='p' || e.key==='Escape'){
+    if(running) paused=!paused;
+    return;
+  }
+  if(!running || paused) return;
+  if(e.key==='ArrowLeft') move(basket.x-20);
+  if(e.key==='ArrowRight') move(basket.x+20);
+});
 
 function spawnItem(){const emoji=emojis[Math.floor(Math.random()*emojis.length)];items.push({emoji,x:Math.random()*(width-32)+16,y:-30,size:30,speed:(2+Math.random()*2)*speedMult});}
 
@@ -44,7 +52,28 @@ function update(dt){spawn+=dt;if(spawn>interval){spawnItem();spawn=0;}items.forE
 
 function draw(){ctx.clearRect(0,0,width,height);ctx.fillStyle='#fff';ctx.fillRect(basket.x,basket.y,basket.width,basket.height);ctx.font='28px serif';items.forEach(it=>ctx.fillText(it.emoji,it.x-15,it.y));}
 
-function loop(t){if(!running)return;requestAnimationFrame(loop);const dt=t-(last||t);last=t;update(dt);draw();updateHUD();}
+function drawPauseOverlay(){
+  ctx.fillStyle='rgba(0,0,0,0.5)';
+  ctx.fillRect(0,0,width,height);
+  ctx.fillStyle='#fff';
+  ctx.font='30px Arial';
+  const msg='Paused';
+  ctx.fillText(msg,width/2-ctx.measureText(msg).width/2,height/2);
+}
+
+function loop(t){
+  if(!running) return;
+  requestAnimationFrame(loop);
+  if(paused){
+    drawPauseOverlay();
+    return;
+  }
+  const dt=t-(last||t);
+  last=t;
+  update(dt);
+  draw();
+  updateHUD();
+}
 
 function updateHUD(){document.getElementById('score').textContent=score;document.getElementById('lives').textContent=lives;document.getElementById('best').textContent=high;document.getElementById('scoreLabel').firstChild.textContent=texts.score+': ';document.getElementById('livesLabel').firstChild.textContent=texts.lives+': ';}
 
@@ -53,14 +82,14 @@ function start(){
   const diff=diffSelect.value;
   if(diff==='easy'){interval=900;speedMult=0.8;}else if(diff==='hard'){interval=500;speedMult=1.4;}else{interval=700;speedMult=1;}
   localStorage.setItem('emojiDifficulty',diff);
-  score=0;lives=3;items=[];running=true;last=0;spawn=interval;
+  score=0;lives=3;items=[];running=true;paused=false;last=0;spawn=interval;
   startBtn.textContent=texts.restart;
   startBtn.disabled=true; // disable while game active
   loop();
 }
 
 function gameOver(){
-  running=false;ctx.fillStyle='rgba(0,0,0,0.5)';ctx.fillRect(0,0,width,height);ctx.fillStyle='#fff';ctx.font='30px Arial';ctx.fillText(texts.gameOver,width/2-ctx.measureText(texts.gameOver).width/2,height/2);
+  running=false;paused=false;ctx.fillStyle='rgba(0,0,0,0.5)';ctx.fillRect(0,0,width,height);ctx.fillStyle='#fff';ctx.font='30px Arial';ctx.fillText(texts.gameOver,width/2-ctx.measureText(texts.gameOver).width/2,height/2);
   high=Math.max(high,score);localStorage.setItem('emojiHigh',high);updateHUD();
   startBtn.disabled=false;
 }


### PR DESCRIPTION
## Summary
- introduce a `paused` state for Emoji Catcher
- allow toggling pause with **P** or **Escape**
- skip game updates when paused and show a pause overlay

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684219891558832daedd174fc50ef00c