### PR TITLE
Fix Pong menu overlay

### DIFF
--- a/doc/fichier.md
+++ b/doc/fichier.md
@@ -16,3 +16,9 @@ Veillez à consigner chaque entrée chronologiquement pour garder une trace clai
 - **Demande** : corriger un problème de sécurité lié aux sessions Express.
 - **Objectif** : générer une clef aléatoire si `SESSION_SECRET` n'est pas défini et ajouter des en-têtes HTTP sécurisés.
 - **Résultat** : ajout de la configuration du module **helmet**, désactivation de `X-Powered-By` et documentation de la variable `SESSION_SECRET`.
+
+## 2025-06-05
+
+- **Demande** : le menu du jeu Pong n'apparaît pas sur certains écrans.
+- **Objectif** : s'assurer que la fenêtre reste visible quel que soit la taille de l'écran.
+- **Résultat** : ajout d'un `max-height` et d'un défilement vertical sur l'overlay pour afficher correctement le menu.

--- a/public/games/pong/pong.css
+++ b/public/games/pong/pong.css
@@ -1,6 +1,6 @@
 body{margin:0;background:#000;color:#fff;font-family:Arial,sans-serif;overflow:hidden}
 canvas{background:#000;display:block;margin:0 auto}
-.overlay{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(0,0,0,0.8);padding:20px;border-radius:8px;text-align:center;color:#fff;overflow:hidden;z-index:10;width:80%;max-width:500px}
+.overlay{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(0,0,0,0.8);padding:20px;border-radius:8px;text-align:center;color:#fff;overflow-y:auto;z-index:10;width:80%;max-width:500px;max-height:90vh}
 .info{font-size:14px;margin-bottom:10px;color:#ccc}
 .hidden{display:none}
 .buttons button, #pauseBtn,.nav button{margin:5px;padding:10px 20px;background:#0055a4;border:none;border-radius:5px;color:#fff;cursor:pointer}


### PR DESCRIPTION
## Summary
- ensure Pong overlay fits on small screens
- document the fix in history

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68422171c288832d8143e75b0846b8d5