### PR TITLE
Fix Pong menu visibility

### DIFF
--- a/public/games/pong/pong.css
+++ b/public/games/pong/pong.css
@@ -1,6 +1,6 @@
 body{margin:0;background:#000;color:#fff;font-family:Arial,sans-serif;overflow:hidden}
-canvas{background:#000;display:block;margin:0 auto}
-.overlay{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(0,0,0,0.8);padding:20px;border-radius:8px;text-align:center;color:#fff;overflow:hidden;z-index:10;width:80%;max-width:500px}
+canvas{background:#000;display:block;margin:0 auto;position:relative;z-index:0}
+.overlay{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(0,0,0,0.8);padding:20px;border-radius:8px;text-align:center;color:#fff;overflow:hidden;z-index:100;width:80%;max-width:500px;border:2px solid #fff}
 .info{font-size:14px;margin-bottom:10px;color:#ccc}
 .hidden{display:none}
 .buttons button, #pauseBtn,.nav button{margin:5px;padding:10px 20px;background:#0055a4;border:none;border-radius:5px;color:#fff;cursor:pointer}


### PR DESCRIPTION
## Summary
- tweak z-index and border for Pong menu

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842238b6ca8832d8eb8496fabc6bbe5