### PR TITLE
Fix back buttons blocked by CSP

### DIFF
--- a/doc/fichier.md
+++ b/doc/fichier.md
@@ -35,3 +35,9 @@ Veillez à consigner chaque entrée chronologiquement pour garder une trace clai
 - **Objectif** : forcer l'import complet du dépôt et notifier l'utilisateur à la fin.
 - **Résultat** : `/api/update` récupère désormais tout le dépôt avec `fetch --all` suivi d'un `reset --hard` et l'interface affiche un message lorsque l'import est terminé.
 
+## 2025-06-08
+
+- **Demande** : les boutons "Retour" ne réagissent pas dans le navigateur.
+- **Objectif** : autoriser les gestionnaires d'événements inline utilisés par les boutons.
+- **Résultat** : configuration de **helmet** pour relâcher la Content Security Policy et permettre `onclick="navigate(...)`.
+

--- a/server.js
+++ b/server.js
@@ -12,7 +12,17 @@ const GAMES_DIR = path.join(__dirname, 'public', 'games');
 
 const app = express();
 app.disable('x-powered-by');
-app.use(helmet());
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", "'unsafe-inline'"],
+        scriptSrcAttr: ["'unsafe-inline'"]
+      },
+    },
+  })
+);
 const USERS_FILE = path.join(__dirname, 'users.json');
 
 function loadUsers() {


### PR DESCRIPTION
## Summary
- relax Helmet's Content Security Policy so inline handlers work
- log the change in `doc/fichier.md`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842243ff9bc832d8428b791b582b9c7