### PR TITLE
Minor UI fix for Pong demo

### DIFF
--- a/doc/fichier.md
+++ b/doc/fichier.md
@@ -47,3 +47,9 @@ Veillez à consigner chaque entrée chronologiquement pour garder une trace clai
 - **Objectif** : afficher les noms de l'équipe de manière plus lisible.
 - **Résultat** : `public/credits.html` utilise une liste stylisée pour les noms et de nouvelles règles CSS ont été ajoutées.
 
+
+## 2025-06-10
+
+- **Demande** : mieux voir la partie de démonstration derrière le menu du Pong.
+- **Objectif** : rendre la fenêtre du menu plus transparente.
+- **Résultat** : l'opacité du fond de `.overlay` est passée de 0.8 à 0.5.

--- a/public/games/pong/pong.css
+++ b/public/games/pong/pong.css
@@ -1,6 +1,6 @@
 body{margin:0;background:#000;color:#fff;font-family:Arial,sans-serif;overflow:hidden}
 canvas{background:#000;display:block;margin:0 auto;position:relative;z-index:0}
-.overlay{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(0,0,0,0.8);padding:20px;border-radius:8px;text-align:center;color:#fff;overflow:hidden;z-index:100;width:80%;max-width:500px;border:2px solid #fff}
+.overlay{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(0,0,0,0.5);padding:20px;border-radius:8px;text-align:center;color:#fff;overflow:hidden;z-index:100;width:80%;max-width:500px;border:2px solid #fff}
 .info{font-size:14px;margin-bottom:10px;color:#ccc}
 .hidden{display:none}
 .buttons button, #pauseBtn,.nav button{margin:5px;padding:10px 20px;background:#0055a4;border:none;border-radius:5px;color:#fff;cursor:pointer}


### PR DESCRIPTION
## Summary
- lighten overlay background for better visibility of the demo match
- log this change in `doc/fichier.md`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684227d82fdc832dbf2bd7ad2ad264e1