### PR TITLE
Fix manual update button refresh

### DIFF
--- a/app/public/js/app.js
+++ b/app/public/js/app.js
@@ -199,7 +199,10 @@ function updateAdminTile(){
 }
 
 // Gestion des différents boutons de l'interface
-manualUpdateButton.addEventListener('click', load);
+manualUpdateButton.addEventListener('click', async () => {
+  await checkUpdate();
+  await load();
+});
 autoUpdateCheckbox.addEventListener('change', e => {
   savePreferences(e.target.checked);
   setupAutoUpdate(e.target.checked);

--- a/doc/fichier.md
+++ b/doc/fichier.md
@@ -66,3 +66,9 @@ Veillez à consigner chaque entrée chronologiquement pour garder une trace clai
 - **Objectif** : isoler le serveur existant dans `app/` et créer un dossier `loader/` capable de mettre à jour `app/` via Git.
 - **Résultat** : nouvelle arborescence `loader/` et `app/`, le premier servant une page de progression et gérant les mises à jour.
 
+## 2025-06-13
+
+- **Demande** : rafraîchir la liste après une mise à jour manuelle.
+- **Objectif** : exécuter `checkUpdate()` avant de recharger les applications.
+- **Résultat** : le bouton de mise à jour lance `checkUpdate()` puis re-génère les tuiles.
+


### PR DESCRIPTION
## Summary
- call `checkUpdate()` when clicking the manual update button
- refresh the apps after the update finishes
- record the change in documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842a40cbf18832daebdfda78c61c0cb