### PR TITLE
Automate server start

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,13 @@ Pour des informations détaillées, consultez [doc/node-installation.md](doc/nod
    ```
    Depuis cette mise à jour, le serveur utilise le middleware **helmet** et
    l'en-tête `X-Powered-By` est désactivé pour renforcer la sécurité.
-   Puis lancez le chargeur :
+2. Lancez l'application (mise à jour puis démarrage automatique) :
    ```bash
    npm start
    ```
-2. Pour démarrer l'application une fois à jour, exécutez :
-   ```bash
-   node app/server.js
-   ```
-3. Dans votre navigateur, rendez‑vous sur [http://localhost:3000/index.html](http://localhost:3000/index.html).
-4. Les tuiles disponibles s'affichent automatiquement à partir du fichier `app/public/apps.json`.
+   Au bout de quelques secondes, la page de connexion est disponible sur
+   [http://localhost:3000/index.html](http://localhost:3000/index.html).
+3. Les tuiles disponibles s'affichent automatiquement à partir du fichier `app/public/apps.json`.
 
 Lors du premier lancement, un utilisateur **admin/admin** est créé automatiquement. Les mots de passe sont maintenant chiffrés avec **bcrypt** et les mots de passe existants sont convertis au premier démarrage.
 Une petite fenêtre de connexion s'affiche : saisissez ces identifiants pour accéder à la plateforme.

--- a/loader/public/index.html
+++ b/loader/public/index.html
@@ -4,15 +4,18 @@
   <meta charset="UTF-8">
   <title>Mise à jour</title>
   <script>
-    async function runUpdate() {
-      try {
-        const res = await fetch('/api/update', { method: 'POST' });
-        const txt = res.ok ? 'Mise à jour terminée' : 'Échec de la mise à jour';
-        document.getElementById('status').textContent = txt;
-      } catch (e) {
-        document.getElementById('status').textContent = 'Erreur';
+      async function runUpdate() {
+        try {
+          const res = await fetch('/api/update', { method: 'POST' });
+          const txt = res.ok ? 'Mise à jour terminée' : 'Échec de la mise à jour';
+          document.getElementById('status').textContent = txt;
+          if (res.ok) {
+            setTimeout(() => (window.location.href = '/index.html'), 1000);
+          }
+        } catch (e) {
+          document.getElementById('status').textContent = 'Erreur';
+        }
       }
-    }
     window.addEventListener('load', runUpdate);
   </script>
 </head>

--- a/loader/server.js
+++ b/loader/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const path = require('path');
 const simpleGit = require('simple-git');
+const { spawn } = require('child_process');
 
 const app = express();
 app.use(express.static(path.join(__dirname, 'public')));
@@ -18,6 +19,7 @@ app.post('/api/update', async (req, res) => {
     await git.fetch(['--all']);
     await git.reset(['--hard', 'origin/main']);
     res.json({ updated: true });
+    res.on('finish', startMainServer);
   } catch (e) {
     console.error('update error', e);
     res.status(500).json({ error: 'git' });
@@ -25,4 +27,13 @@ app.post('/api/update', async (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => console.log('Loader listening on ' + PORT));
+const server = app.listen(PORT, () => console.log('Loader listening on ' + PORT));
+
+function startMainServer() {
+  const child = spawn(process.execPath, [path.join(__dirname, '..', 'app', 'server.js')], {
+    detached: true,
+    stdio: 'inherit'
+  });
+  child.unref();
+  server.close(() => process.exit(0));
+}


### PR DESCRIPTION
## Summary
- start the main server automatically when update finishes
- redirect to login page after successful update
- document the new startup behavior

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842a8ef1be4832da08cc6e0e4745d7f