### PR TITLE
Fix duplicate Pong quit handler

### DIFF
--- a/app/public/games/pong/pong.js
+++ b/app/public/games/pong/pong.js
@@ -138,8 +138,6 @@ function updatePage(){
   pages.style.transform = `translateX(-${currentPage*100}%)`;
 }
 
-document.getElementById('quitBtn').addEventListener('click', () => {paused=false;pauseOverlay.classList.add('hidden');endGame();});
-
 // Navigation et paramètres
 document.getElementById('startBtn').addEventListener('click', () => {currentPage=1;updatePage();});
 document.querySelectorAll('.next').forEach(btn=>btn.addEventListener('click',()=>{currentPage++;updatePage();}));

--- a/doc/fichier.md
+++ b/doc/fichier.md
@@ -85,3 +85,8 @@ Veillez à consigner chaque entrée chronologiquement pour garder une trace clai
 - **Objectif** : permettre de choisir le mode de jeu, la taille de la grille et la longueur d'alignement.
 - **Résultat** : nouvelle interface multi-pages dans `connect4/index.html` et logique mise à jour dans `connect4.js`.
 
+## 2025-06-16
+
+- **Demande** : corriger le double enregistrement du bouton "Quitter" dans Pong.
+- **Objectif** : s'assurer que la sortie du jeu ne soit déclenchée qu'une seule fois.
+- **Résultat** : une ligne en double a été retirée dans `pong.js`.


### PR DESCRIPTION
## Summary
- remove duplicate click listener for Pong quit button
- document change in modification history

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842b78044c0832da9704e95f3f02f63