### PR TITLE
Fix history injection in Pong

### DIFF
--- a/app/public/games/pong/pong.js
+++ b/app/public/games/pong/pong.js
@@ -58,7 +58,12 @@ function savePrefs(){
 // Affiche l'historique des scores
 function loadHistory(){
   const hist = JSON.parse(localStorage.getItem('pongHistory')||'[]');
-  historyBox.innerHTML = hist.map(h=>`<div>${h.p1} ${h.s1} - ${h.s2} ${h.p2}</div>`).join('');
+  historyBox.innerHTML = '';
+  hist.forEach(h => {
+    const div = document.createElement('div');
+    div.textContent = `${h.p1} ${h.s1} - ${h.s2} ${h.p2}`;
+    historyBox.appendChild(div);
+  });
 }
 // Sauvegarde un nouveau résultat dans l'historique
 function addHistory(entry){

--- a/doc/fichier.md
+++ b/doc/fichier.md
@@ -90,3 +90,9 @@ Veillez à consigner chaque entrée chronologiquement pour garder une trace clai
 - **Demande** : corriger le double enregistrement du bouton "Quitter" dans Pong.
 - **Objectif** : s'assurer que la sortie du jeu ne soit déclenchée qu'une seule fois.
 - **Résultat** : une ligne en double a été retirée dans `pong.js`.
+
+## 2025-06-17
+
+- **Demande** : empêcher l'injection de code HTML via les noms des joueurs dans l'historique de Pong.
+- **Objectif** : sécuriser l'affichage des entrées d'historique.
+- **Résultat** : `pong.js` construit désormais chaque entrée avec `textContent` au lieu de `innerHTML`.


### PR DESCRIPTION
## Summary
- sanitize Pong history entries by constructing nodes with textContent
- document the security fix in the changelog

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842b8c75678832da8813f5e112d67d0