### PR TITLE
Fix menu overlay centering in Pong

### DIFF
--- a/app/public/games/pong/pong.css
+++ b/app/public/games/pong/pong.css
@@ -1,6 +1,6 @@
 body{margin:0;background:#000;color:#fff;font-family:Arial,sans-serif;overflow:hidden}
 canvas{background:#000;display:block;margin:0 auto;position:relative;z-index:0}
-.overlay{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%) scale(1);background:rgba(0,0,0,0.6);padding:20px;border-radius:8px;text-align:center;color:#fff;z-index:100;width:80%;max-width:500px;border:2px solid #fff;opacity:1;transition:opacity .3s,transform .3s}
+.overlay{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%) scale(1);background:rgba(0,0,0,0.6);padding:20px;border-radius:8px;text-align:center;color:#fff;z-index:100;width:80%;max-width:500px;border:2px solid #fff;opacity:1;transition:opacity .3s,transform .3s;display:flex;flex-direction:column;align-items:center;justify-content:center}
 .overlay.hidden{opacity:0;transform:translate(-50%,-50%) scale(0.9);pointer-events:none}
 .pages{display:flex;width:400%;transition:transform .5s}
 .page{width:100%;flex-shrink:0;box-sizing:border-box}

--- a/doc/fichier.md
+++ b/doc/fichier.md
@@ -102,3 +102,8 @@ Veillez à consigner chaque entrée chronologiquement pour garder une trace clai
 - **Demande** : enrichir le Pong avec une nouvelle version plus modulable.
 - **Objectif** : réécrire le jeu avec des classes pour faciliter les évolutions et ajouter des options de vitesse, une IA réglable et des power-ups.
 - **Résultat** : nouveaux fichiers `engine.js`, `pong.js` et `pong.css` avec un menu animé et la prise en charge des nouvelles options.
+
+## 2025-06-19
+- **Demande** : centrer l'affichage du menu de Pong.
+- **Objectif** : s'assurer que la fenetre de menu apparaisse toujours au milieu de l'ecran.
+- **Resultat** : la classe `.overlay` utilise desormais Flexbox pour placer son contenu au centre.


### PR DESCRIPTION
## Summary
- center menu overlay using Flexbox in `pong.css`
- document change in `doc/fichier.md`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842f9027864832d9a58bec37336e385