### PR TITLE
Add PR test tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Il est désormais possible de créer d'autres comptes directement depuis l'écra
 - **Mise à jour** : la page lit le fichier `app/public/apps.json` pour afficher les applications. Le bouton "Paramètres" permet d'activer la mise à jour automatique ou d'exécuter une mise à jour manuelle. Il est désormais possible de préciser la branche via `branch=` ou le numéro de pull request via `pr=` lors de l'appel à `/api/update`.
 - **Jeux** : la tuile "C02 Games" mène à un sous‑menu mis à jour automatiquement à chaque chargement. La liste est construite en scannant les fichiers HTML du dossier `app/public/games`. On y trouve un Pong jouable en solo ou à deux sur le même clavier, un Puissance 4 jouable en 1v1 ou contre l'ordinateur, ainsi que le jeu "Emoji Catcher".
 - **Discord** : la tuile "C02 Discord" ouvrira le lien vers le serveur [Discord](https://discord.gg/AD6DvdaRyR).
+- **Tester une PR** : la tuile "Tester une PR" permet de saisir un numéro de pull request et lance `/api/update?pr=` pour mettre l'application à jour depuis cette PR.
 - **Gestion Users** : disponible uniquement pour les administrateurs, permet d'ajouter, modifier ou supprimer les comptes enregistrés côté serveur.
 - **Déconnexion** : un bouton en haut à droite permet de quitter la session courante.
 

--- a/app/public/apps.json
+++ b/app/public/apps.json
@@ -2,6 +2,7 @@
   "apps": [
     { "id": "credits", "name": "Crédits", "link": "credits.html" },
     { "id": "games", "name": "C02 Games", "link": "games/index.html" },
-    { "id": "discord", "name": "C02 Discord", "link": "https://discord.gg/AD6DvdaRyR" }
+    { "id": "discord", "name": "C02 Discord", "link": "https://discord.gg/AD6DvdaRyR" },
+    { "id": "pr", "name": "Tester une PR", "link": "update.html" }
   ]
 }

--- a/app/public/js/update.js
+++ b/app/public/js/update.js
@@ -1,0 +1,12 @@
+const prInput = document.getElementById('prNumber');
+const applyBtn = document.getElementById('applyPr');
+
+applyBtn.addEventListener('click', async () => {
+  const pr = prInput.value.trim();
+  if (!pr) {
+    alert('Veuillez saisir un numéro de pull request');
+    return;
+  }
+  await fetch(`/api/update?pr=${encodeURIComponent(pr)}`, { method: 'POST' });
+  navigate('index.html');
+});

--- a/app/public/update.html
+++ b/app/public/update.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>Tester une PR</title>
+<link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+<h1>Tester une Pull Request</h1>
+<button class="back-button" onclick="navigate('index.html')">Retour</button>
+<div>
+  <label>Numéro de PR <input id="prNumber" type="number" min="1"></label>
+</div>
+<button id="applyPr">Mettre à jour</button>
+<script src="js/transition.js"></script>
+<script src="js/update.js"></script>
+</body>
+</html>

--- a/doc/fichier.md
+++ b/doc/fichier.md
@@ -112,3 +112,8 @@ Veillez à consigner chaque entrée chronologiquement pour garder une trace clai
 - **Demande** : pouvoir tester une branche ou une pull request avant son intégration.
 - **Objectif** : choisir la référence Git à récupérer lors d'une mise à jour.
 - **Résultat** : l'API `/api/update` accepte maintenant les paramètres `branch` ou `pr` pour pointer vers la branche ou la pull request désirée.
+
+## 2025-06-21
+- **Demande** : ajouter une tuile pour tester une pull request.
+- **Objectif** : sélectionner le numéro de PR à utiliser lors de la mise à jour.
+- **Résultat** : nouvelle page `update.html` accessible via la tuile "Tester une PR" et appel de `/api/update?pr=`.


### PR DESCRIPTION
## Summary
- add `update.html` page with a field to specify pull request number
- call `/api/update?pr=` from new `update.js`
- list new tile `Tester une PR` in `apps.json`
- document this tile in README and history

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843022c17a0832d9e61691c3317d729