### PR TITLE
Validate numeric pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Il est désormais possible de créer d'autres comptes directement depuis l'écra
 
 ## Fonctionnement
 
-- **Mise à jour** : la page lit le fichier `app/public/apps.json` pour afficher les applications. Le bouton "Paramètres" permet d'activer la mise à jour automatique ou d'exécuter une mise à jour manuelle. Il est désormais possible de préciser la branche via `branch=` ou le numéro de pull request via `pr=` lors de l'appel à `/api/update`.
+- **Mise à jour** : la page lit le fichier `app/public/apps.json` pour afficher les applications. Le bouton "Paramètres" permet d'activer la mise à jour automatique ou d'exécuter une mise à jour manuelle. Il est désormais possible de préciser la branche via `branch=` ou le numéro de pull request via `pr=` (uniquement un nombre) lors de l'appel à `/api/update`.
 - **Jeux** : la tuile "C02 Games" mène à un sous‑menu mis à jour automatiquement à chaque chargement. La liste est construite en scannant les fichiers HTML du dossier `app/public/games`. On y trouve un Pong jouable en solo ou à deux sur le même clavier, un Puissance 4 jouable en 1v1 ou contre l'ordinateur, ainsi que le jeu "Emoji Catcher".
 - **Discord** : la tuile "C02 Discord" ouvrira le lien vers le serveur [Discord](https://discord.gg/AD6DvdaRyR).
 - **Cha\u00eene YouTube** : permet de consulter une vid\u00e9o depuis une page int\u00e9gr\u00e9e.
-- **Tester une PR** : la tuile "Tester une PR" permet de saisir un num\u00e9ro de pull request et lance `/api/update?pr=` pour mettre l'application \u00e0 jour depuis cette PR.
+- **Tester une PR** : la tuile "Tester une PR" permet de saisir un numéro de pull request (uniquement numérique) et lance `/api/update?pr=` pour mettre l'application \u00e0 jour depuis cette PR.
 - **Gestion Users** : disponible uniquement pour les administrateurs, permet d'ajouter, modifier ou supprimer les comptes enregistrés côté serveur.
 - **Déconnexion** : un bouton en haut à droite permet de quitter la session courante.
 

--- a/app/server.js
+++ b/app/server.js
@@ -146,6 +146,9 @@ app.post('/api/update', async (req, res) => {
 
     const branch = req.body.branch || req.query.branch;
     const pr = req.body.pr || req.query.pr;
+    if (pr && !/^\d+$/.test(pr)) {
+      return res.status(400).json({ error: 'invalid pr' });
+    }
 
     await git.fetch(['--all']);
     if (pr) {

--- a/doc/fichier.md
+++ b/doc/fichier.md
@@ -122,3 +122,8 @@ Veillez à consigner chaque entrée chronologiquement pour garder une trace clai
 - **Demande** : intégrer une page YouTube dans l'application.
 - **Objectif** : ajouter une tuile permettant d'accéder à un lecteur YouTube intégré.
 - **Résultat** : nouvelle page `youtube.html` et entrée correspondante dans `apps.json`.
+
+## 2025-06-23
+- **Demande** : valider le numéro de pull request envoyé à `/api/update`.
+- **Objectif** : empêcher l'appel avec une valeur non numérique.
+- **Résultat** : les serveurs renvoient `400` si `pr` n'est pas un nombre et la documentation précise cette contrainte.

--- a/loader/server.js
+++ b/loader/server.js
@@ -20,6 +20,9 @@ app.post('/api/update', async (req, res) => {
 
     const branch = req.body.branch || req.query.branch;
     const pr = req.body.pr || req.query.pr;
+    if (pr && !/^\d+$/.test(pr)) {
+      return res.status(400).json({ error: 'invalid pr' });
+    }
 
     await git.fetch(['--all']);
     if (pr) {


### PR DESCRIPTION
## Summary
- validate the `pr` parameter in loader and app servers
- document that PR numbers must be numeric
- record changes in the history file

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843057efe58832d9df07c047d0cc6f8