### PR TITLE
Ajout fichier info.json pour chaque jeu

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Il est désormais possible de créer d'autres comptes directement depuis l'écra
 ## Fonctionnement
 
 - **Mise à jour** : la page lit le fichier `app/public/apps.json` pour afficher les applications. Le bouton "Paramètres" permet d'activer la mise à jour automatique ou d'exécuter une mise à jour manuelle. Il est désormais possible de préciser la branche via `branch=` ou le numéro de pull request via `pr=` (uniquement un nombre) lors de l'appel à `/api/update`.
-- **Jeux** : la tuile "C02 Games" mène à un sous‑menu mis à jour automatiquement à chaque chargement. La liste est construite en scannant les fichiers HTML du dossier `app/public/games`. On y trouve un Pong jouable en solo ou à deux sur le même clavier, un Puissance 4 jouable en 1v1 ou contre l'ordinateur, ainsi que le jeu "Emoji Catcher".
+- **Jeux** : la tuile "C02 Games" mène à un sous‑menu mis à jour automatiquement à chaque chargement. Chaque dossier dans `app/public/games` contient désormais un fichier `info.json` indiquant le nom du jeu et la page HTML à ouvrir. On y trouve un Pong jouable en solo ou à deux sur le même clavier, un Puissance 4 jouable en 1v1 ou contre l'ordinateur, ainsi que le jeu "Emoji Catcher".
 - **Discord** : la tuile "C02 Discord" ouvrira le lien vers le serveur [Discord](https://discord.gg/AD6DvdaRyR).
 - **Cha\u00eene YouTube** : permet de consulter une vid\u00e9o depuis une page int\u00e9gr\u00e9e.
 - **Tester une PR** : la tuile "Tester une PR" liste les cinq dernières pull requests du dépôt. Choisissez-en une puis cliquez sur **Charger la PR** pour l'utiliser. Le bouton **Décharger** ramène l'application sur la branche principale.

--- a/app/public/games/connect4/info.json
+++ b/app/public/games/connect4/info.json
@@ -1,0 +1,4 @@
+{
+  "name": "Puissance 4",
+  "page": "index.html"
+}

--- a/app/public/games/emoji/info.json
+++ b/app/public/games/emoji/info.json
@@ -1,0 +1,4 @@
+{
+  "name": "Emoji Catcher",
+  "page": "index.html"
+}

--- a/app/public/games/pong/info.json
+++ b/app/public/games/pong/info.json
@@ -1,0 +1,4 @@
+{
+  "name": "Pong",
+  "page": "index.html"
+}

--- a/app/server.js
+++ b/app/server.js
@@ -297,19 +297,18 @@ app.get('/api/games', (req, res) => {
     entries
       .filter((e) => e.isDirectory())
       .forEach((dir) => {
-        const indexFile = path.join(GAMES_DIR, dir.name, 'index.html');
-        if (!fs.existsSync(indexFile)) return;
-        let title = dir.name;
+        const infoFile = path.join(GAMES_DIR, dir.name, 'info.json');
+        if (!fs.existsSync(infoFile)) return;
         try {
-          const contents = fs.readFileSync(indexFile, 'utf8');
-          const m = contents.match(/<title>([^<]+)<\/title>/i);
-          if (m) title = m[1];
-        } catch (e) {}
-        games.push({
-          id: dir.name,
-          name: title,
-          link: path.join(dir.name, 'index.html'),
-        });
+          const info = JSON.parse(fs.readFileSync(infoFile, 'utf8'));
+          games.push({
+            id: dir.name,
+            name: info.name || dir.name,
+            link: path.join(dir.name, info.page || 'index.html'),
+          });
+        } catch (e) {
+          // ignore invalid info files
+        }
       });
     res.json({ games });
   });

--- a/doc/fichier.md
+++ b/doc/fichier.md
@@ -147,3 +147,8 @@ Veillez à consigner chaque entrée chronologiquement pour garder une trace clai
 - **Demande** : ajouter un système de logs et corriger les erreurs lors de la récupération des PR.
 - **Objectif** : tracer les actions du serveur et éviter l'affichage de "Erreur lors du chargement des pull requests.".
 - **Résultat** : nouvelle librairie `logger.js`, rotation automatique des fichiers, journalisation des routes principales et meilleure gestion des réponses GitHub.
+
+## 2025-06-28
+- **Demande** : simplifier l'ajout de nouveaux jeux.
+- **Objectif** : décrire chaque jeu dans un petit fichier dédié au sein de son dossier.
+- **Résultat** : un fichier `info.json` renseigne le nom du jeu et la page HTML à ouvrir, et l'API `/api/games` lit désormais ces fichiers.


### PR DESCRIPTION
## Summary
- chaque dossier de jeu contient maintenant `info.json` avec le nom et la page HTML
- le serveur lit ces fichiers pour construire la liste des jeux
- mise à jour du README et de la doc

## Testing
- `npm test` *(échoue : `Error: no test specified`)*

------
https://chatgpt.com/codex/tasks/task_e_684314f88f7c832d992025daf37d435c